### PR TITLE
Add mode switching and batch logic for Large Chemical Reactor

### DIFF
--- a/src/main/java/com/roll_54/roll_mod/machine/menu/LCRMenu.java
+++ b/src/main/java/com/roll_54/roll_mod/machine/menu/LCRMenu.java
@@ -24,8 +24,19 @@ public class LCRMenu extends AbstractContainerMenu {
         }
 
         addDataSlot(new DataSlot() {
-            @Override public int get() { return mode; }
-            @Override public void set(int value) { mode = value; }
+            @Override
+            public int get() {
+                var be = level.getBlockEntity(pos);
+                if (be instanceof LargeChemicalReactorBlockEntity lcr) {
+                    return lcr.getModeInt();
+                }
+                return 0;
+            }
+
+            @Override
+            public void set(int value) {
+                mode = value;
+            }
         });
 
         // TODO: додай слоти інвентарю/машини за потреби

--- a/src/main/java/com/roll_54/roll_mod/net/NetRegistration.java
+++ b/src/main/java/com/roll_54/roll_mod/net/NetRegistration.java
@@ -15,7 +15,6 @@ public final class NetRegistration {
     @SubscribeEvent
     public static void register(RegisterPayloadHandlersEvent event) {
         var registrar = event.registrar(Roll_mod.MODID);
-c
         registrar.playToServer(
                 C2SSwitchModePayload.TYPE,
                 C2SSwitchModePayload.STREAM_CODEC,
@@ -23,13 +22,13 @@ c
         );
     }
 
-   private static void handleSwitchMode(final C2SSwitchModePayload msg, final IPayloadContext ctx) {
+    private static void handleSwitchMode(final C2SSwitchModePayload msg, final IPayloadContext ctx) {
         ctx.workHandler().submitAsync(() -> {
             ServerPlayer player = (ServerPlayer) ctx.player().orElse(null);
             if (player == null) return;
 
             var be = player.serverLevel().getBlockEntity(msg.pos());
-            if (be instanceof com.roll_54.roll_mod.machine.LargeChemicalReactorBlockEntity lcr) {
+            if (be instanceof LargeChemicalReactorBlockEntity lcr) {
                 lcr.cycleMode();
             }
         });


### PR DESCRIPTION
## Summary
- Introduce LCR/UCR modes for Large Chemical Reactor block entity with dynamic recipe type and batch sizes
- Sync machine mode through menu and network payload
- Register payload handler for mode switching

## Testing
- `./gradlew build` *(fails: Could not resolve org.appliedenergistics:guideme:21.1.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bca2c5b48330aacd40bf6502d8b4