### PR TITLE
Add storm-based recipe condition

### DIFF
--- a/src/main/java/com/roll_54/roll_mod/Roll_mod.java
+++ b/src/main/java/com/roll_54/roll_mod/Roll_mod.java
@@ -4,7 +4,6 @@ import com.roll_54.roll_mod.ModArmor.ModArmorMaterials;
 import com.roll_54.roll_mod.init.ItemGroups;
 import com.roll_54.roll_mod.init.ItemRegistry;
 import com.roll_54.roll_mod.mi.MIConditionsBootstrap;
-import com.roll_54.roll_mod.mi.NetherStormProcessCondition;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
@@ -25,6 +24,8 @@ public final class Roll_mod {
         ItemRegistry.register(modBus);
         ItemGroups.register(modBus);
         ModArmorMaterials.register(modBus);
+        modBus.addListener(this::onCommonSetup);
+        modBus.addListener(this::onClientSetup);
 
         LOGGER.info("[{}] init complete.", MODID);
     }

--- a/src/main/java/com/roll_54/roll_mod/mi/CustomProcessCondition.java
+++ b/src/main/java/com/roll_54/roll_mod/mi/CustomProcessCondition.java
@@ -1,0 +1,52 @@
+package com.roll_54.roll_mod.mi;
+
+import aztech.modern_industrialization.machines.recipe.MachineRecipe;
+import aztech.modern_industrialization.machines.recipe.condition.MachineProcessCondition;
+import com.mojang.serialization.MapCodec;
+import com.roll_54.roll_mod.netherstorm.StormHandler;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+import java.util.List;
+
+/**
+ * A simple process condition that only succeeds while the custom storm is active.
+ */
+public record CustomProcessCondition() implements MachineProcessCondition {
+
+    public static final CustomProcessCondition INSTANCE = new CustomProcessCondition();
+
+    public static final MapCodec<CustomProcessCondition> CODEC = MapCodec.unit(INSTANCE);
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, CustomProcessCondition> STREAM_CODEC =
+            StreamCodec.unit(INSTANCE);
+
+    @Override
+    public boolean canProcessRecipe(Context context, MachineRecipe recipe) {
+        return StormHandler.isStormActive();
+    }
+
+    @Override
+    public void appendDescription(List<Component> list) {
+        list.add(Component.translatable("mi.condition.roll_mod.nether_storm.active"));
+    }
+
+    @Override
+    public ItemStack icon() {
+        return new ItemStack(Items.WITHER_SKELETON_SKULL);
+    }
+
+    @Override
+    public MapCodec<? extends MachineProcessCondition> codec() {
+        return CODEC;
+    }
+
+    @Override
+    public StreamCodec<? super RegistryFriendlyByteBuf, ? extends MachineProcessCondition> streamCodec() {
+        return STREAM_CODEC;
+    }
+}
+

--- a/src/main/java/com/roll_54/roll_mod/mi/MIConditionsBootstrap.java
+++ b/src/main/java/com/roll_54/roll_mod/mi/MIConditionsBootstrap.java
@@ -2,31 +2,40 @@ package com.roll_54.roll_mod.mi;
 
 import aztech.modern_industrialization.machines.recipe.condition.MachineProcessConditions;
 import net.minecraft.resources.ResourceLocation;
+import org.slf4j.Logger;
 
 public final class MIConditionsBootstrap {
+    private static final Logger LOGGER = com.roll_54.roll_mod.Roll_mod.LOGGER;
+
     private MIConditionsBootstrap() {}
 
     public static void init() {
-        var STORM = net.minecraft.resources.ResourceLocation.fromNamespaceAndPath("roll_mod", "nether_storm_active");
-        var STORM_IN_DIM = net.minecraft.resources.ResourceLocation.fromNamespaceAndPath("roll_mod", "nether_storm_active_in_dimension");
+        LOGGER.debug("[MI] Starting condition registration");
 
-        aztech.modern_industrialization.machines.recipe.condition.MachineProcessConditions.register(
+        var STORM = ResourceLocation.fromNamespaceAndPath("roll_mod", "nether_storm_active");
+        LOGGER.debug("[MI] Created id for nether storm condition: {}", STORM);
+        var STORM_IN_DIM = ResourceLocation.fromNamespaceAndPath("roll_mod", "nether_storm_active_in_dimension");
+        LOGGER.debug("[MI] Created id for nether storm in dimension condition: {}", STORM_IN_DIM);
+
+        LOGGER.debug("[MI] Registering {}", STORM);
+        MachineProcessConditions.register(
                 STORM,
-                NetherStormProcessCondition.CODEC,
-                NetherStormProcessCondition.STREAM_CODEC
+                CustomProcessCondition.CODEC,
+                CustomProcessCondition.STREAM_CODEC
         );
-        com.roll_54.roll_mod.Roll_mod.LOGGER.info("[MI] Registered process condition {}", STORM);
+        LOGGER.debug("[MI] Registered {}", STORM);
 
-        aztech.modern_industrialization.machines.recipe.condition.MachineProcessConditions.register(
+        LOGGER.debug("[MI] Registering {}", STORM_IN_DIM);
+        MachineProcessConditions.register(
                 STORM_IN_DIM,
                 NetherStormInDimensionProcessCondition.CODEC,
                 NetherStormInDimensionProcessCondition.STREAM_CODEC
         );
-        com.roll_54.roll_mod.Roll_mod.LOGGER.info("[MI] Registered process condition {}", STORM_IN_DIM);
+        LOGGER.debug("[MI] Registered {}", STORM_IN_DIM);
 
         // sanity-check, що воно реально в реєстрі
-        var check = aztech.modern_industrialization.machines.recipe.condition.MachineProcessConditions
-                .getCodec(STORM);
-        com.roll_54.roll_mod.Roll_mod.LOGGER.info("[MI] Lookup '{}': {}", STORM, (check != null ? "OK" : "MISSING"));
+        LOGGER.debug("[MI] Performing lookup check for {}", STORM);
+        var check = MachineProcessConditions.getCodec(STORM);
+        LOGGER.debug("[MI] Lookup '{}': {}", STORM, (check != null ? "OK" : "MISSING"));
     }
 }

--- a/src/main/resources/assets/roll_mod/lang/en_us.json
+++ b/src/main/resources/assets/roll_mod/lang/en_us.json
@@ -22,7 +22,7 @@
   "message.roll_mod.nether_storm.end": "The storm has stopped... but for how long?",
 
   "tag.item.roll_mod.storm_protective": "Storm Protective",
-
+  "mi.condition.roll_mod.nether_storm.active": "Requires the nether storm to be active",
 
   "item.roll_mod.meteorite_metal_ingot": "Meteorite Ingot",
   "loreitem.roll_mod.meteorite_metal_ingot.tooltip_line1": "A fragment forged in cosmic fire.",

--- a/src/main/resources/assets/roll_mod/lang/uk_ua.json
+++ b/src/main/resources/assets/roll_mod/lang/uk_ua.json
@@ -20,6 +20,7 @@
   "message.roll_mod.nether_storm.end": "Шторм зупинився, а наскільки довго?",
 
   "tag.item.roll_mod.storm_protective": "Захист від шторму",
+  "mi.condition.roll_mod.nether_storm.active": "Потрібен активний шторм у Незері",
 
   "loreitem.roll_mod.hazmat_helmet.tooltip_line1": "Без цього не вижити в Незері в наші дні.",
   "loreitem.roll_mod.hazmat_helmet.tooltip_line2": "Естетика покинула чат...",

--- a/src/main/resources/data/modern_industrialization/recipe/example.json
+++ b/src/main/resources/data/modern_industrialization/recipe/example.json
@@ -10,8 +10,6 @@
     { "fluid": "modern_industrialization:styrene_butadiene_rubber", "amount": 6000 }
   ],
   "process_conditions": [
-    {
-      "type": "roll_mod:nether_storm_active"}
-
+    { "type": "roll_mod:nether_storm_active" }
   ]
 }


### PR DESCRIPTION
## Summary
- add detailed debug logs while registering custom process conditions
- document how to require an active Nether storm in the example recipe
- ensure common setup runs so the storm condition registers before recipes load

## Testing
- `./gradlew build` *(fails: Could not resolve org.appliedenergistics:guideme:21.1.5. Received status code 403 from server: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c76d2e1594833085b928a1fc788046